### PR TITLE
Astillero agregado de productos en base a servicio

### DIFF
--- a/src/AppBundle/Controller/Astillero/ServicioController.php
+++ b/src/AppBundle/Controller/Astillero/ServicioController.php
@@ -2,12 +2,15 @@
 
 namespace AppBundle\Controller\Astillero;
 
+use AppBundle\Entity\Astillero\GrupoProducto;
 use AppBundle\Entity\Astillero\Servicio;
+use AppBundle\Repository\Astillero\GrupoProductoRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -72,17 +75,15 @@ class ServicioController extends Controller
      * @Route("/buscarservicio/{id}.{_format}", name="ajax_astillero_busca_servicio", defaults={"_format"="json"})
      *
      */
-    public function buscarAction(Request $request, Servicio $servicio){
-        $encoders = [new XmlEncoder(), new JsonEncoder()];
-        $normalizer = new ObjectNormalizer();
-        $normalizer->setCircularReferenceLimit(1);
-        $normalizer->setCircularReferenceHandler(function ($object) {
-            return $object->getId();
-        });
-        $normalizer->setIgnoredAttributes(['aCotizacionesServicios']);
-        $normalizers = [$normalizer];
-        $serializer = new Serializer($normalizers, $encoders);
-        return new Response($servicio = $serializer->serialize($servicio,$request->getRequestFormat()));
+    public function buscarAction(Request $request, $id)
+    {
+        $grupoProductoRepository = $this->getDoctrine()->getRepository(GrupoProducto::class);
+        return new JsonResponse(
+          [
+              'gruposProductos' => $grupoProductoRepository->getGrupoFromServicio($id)
+          ],
+          JsonResponse::HTTP_OK
+        );
     }
 
     /**

--- a/src/AppBundle/Entity/Astillero/GrupoProducto.php
+++ b/src/AppBundle/Entity/Astillero/GrupoProducto.php
@@ -45,6 +45,12 @@ class GrupoProducto
     private $observaciones;
 
     /**
+     * @var Servicio
+     * @ORM\ManyToMany(targetEntity="AppBundle\Entity\Astillero\Servicio", mappedBy="gruposProductos")
+     */
+    private $servicio;
+
+    /**
      * @ORM\ManyToOne(targetEntity="AppBundle\Entity\Astillero\Producto")
      * @ORM\JoinColumn(name="idproducto", referencedColumnName="id")
      */
@@ -159,5 +165,21 @@ class GrupoProducto
     public function getTipoCantidad()
     {
         return $this->tipoCantidad;
+    }
+
+    /**
+     * @return Servicio
+     */
+    public function getServicio()
+    {
+        return $this->servicio;
+    }
+
+    /**
+     * @param Servicio $servicio
+     */
+    public function setServicio($servicio)
+    {
+        $this->servicio = $servicio;
     }
 }

--- a/src/AppBundle/Entity/Astillero/Servicio.php
+++ b/src/AppBundle/Entity/Astillero/Servicio.php
@@ -70,11 +70,20 @@ class Servicio
     private $descripcion;
 
     /**
-     * @ORM\ManyToMany(targetEntity="AppBundle\Entity\Astillero\GrupoProducto",cascade={"persist"})
-     * @ORM\JoinTable(name="servicios_gruposproductos",
-     *      joinColumns={@ORM\JoinColumn(name="idservicio", referencedColumnName="id")},
-     *      inverseJoinColumns={@ORM\JoinColumn(name="idgrupoproducto", referencedColumnName="id", unique=true)}
-     *      )
+     * @ORM\ManyToMany(
+     *     targetEntity="AppBundle\Entity\Astillero\GrupoProducto",
+     *     inversedBy="servicio",
+     *     cascade={"persist"}
+     *     )
+     * @ORM\JoinTable(
+     *     name="servicios_gruposproductos",
+     *     joinColumns={
+     *      @ORM\JoinColumn(name="idservicio", referencedColumnName="id")
+     *     },
+     *     inverseJoinColumns={
+     *      @ORM\JoinColumn(name="idgrupoproducto", referencedColumnName="id", unique=true)
+     *     }
+     *     )
      */
     private $gruposProductos;
 

--- a/src/AppBundle/Repository/Astillero/GrupoProductoRepository.php
+++ b/src/AppBundle/Repository/Astillero/GrupoProductoRepository.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * User: inrumi
+ * Date: 8/16/18
+ * Time: 11:57
+ */
+
+namespace AppBundle\Repository\Astillero;
+
+
+use Doctrine\ORM\EntityRepository;
+
+class GrupoProductoRepository extends EntityRepository
+{
+    public function getGrupoFromServicio($servicioId)
+    {
+        $query = $this->getEntityManager()
+            ->createQuery(
+                'SELECT grupo, producto '.
+                'FROM AppBundle:Astillero\GrupoProducto grupo '.
+                'LEFT JOIN grupo.producto producto '.
+                'LEFT JOIN grupo.servicio servicio '.
+                'WHERE servicio.id = :id'
+            )
+            ->setParameter('id', $servicioId);
+
+        return $query->getArrayResult();
+    }
+}

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -326,29 +326,37 @@ function astilleroAgregaProducto(grupoProducto,idservicio){
     var totServicios = $('#serviciosextra').data('cantidad');
     var servicioListPrimero = jQuery('#productos');
     var newWidget = $('#serviciosextra').data('prototype');
+
     newWidget = newWidget.replace(/__name__/g, totServicios);
     newWidget = newWidget.replace('td-otroservicio', 'hide');
     newWidget = newWidget.replace('td-servicio', 'hide');
     newWidget = newWidget.replace('td-libre', 'hide');
     newWidget = newWidget.replace('input-group', 'hide');
+
     totServicios++;
+
     $('#serviciosextra').data('cantidad', totServicios);
+
     var newLi = jQuery('<tr class="servicio-agregado" data-id="' + (totServicios - 1) + '"></tr>').html(newWidget);
+
     newLi.appendTo(servicioListPrimero);
     newLi.before(newLi);
+
     var fila = $('#appbundle_astillerocotizacion_acservicios_' + (totServicios - 1) + '_producto').parent().parent();
+
     fila.children('.valorpromedio').removeClass('hide'); //hacer visible columna de valor promedio solo para productos en caso de que pertenezcan a un servicio
 
-    if(grupoProducto === 0){
+    if (grupoProducto === 0) {
         $('#appbundle_astillerocotizacion_acservicios_' + (totServicios - 1) + '_cantidad').val(1);
         $('#appbundle_astillerocotizacion_acservicios_' + (totServicios - 1) + '_cantidad').parent().data('valor', 1);
         $('#appbundle_astillerocotizacion_acservicios_' + (totServicios - 1) + '_producto').val('');
-    }else{
+    } else {
         var productosCantidad = 0;
         var eslora = typeof($('#eslora').data('valor')) === 'undefined' ? 0 : $('#eslora').data('valor');
-        if(grupoProducto.tipoCantidad){
+
+        if (grupoProducto.tipoCantidad) {
             productosCantidad = Math.round(eslora * grupoProducto.cantidad);
-        }else{
+        } else {
             productosCantidad = grupoProducto.cantidad;
         }
         //fila.data('servicio-pertenece',idservicio);
@@ -433,17 +441,18 @@ $('.add-servicio').click(function (e) {
     $(fila.children('.valorprecio')).data('valorreal',precioreal);
     $(fila.children('.valorprecio')).data('divisa',$(this).data('divisa'));
     calculaSubtotalesAstillero(fila);
-    let url = `${location.protocol + '//' + location.host}/astillero/servicio/buscarservicio/${idservicio}`;
+
+    // let url = `${location.protocol + '//' + location.host}/astillero/servicio/buscarservicio/${idservicio}`;
+
     $.ajax({
         method: "GET",
-        url: url,
+        url: location.pathname + '../../../servicio/buscarservicio/' + idservicio,
         dataType: 'json',
-        success: function(datos) {
-            $.each(datos.gruposProductos, function (i, grupoProducto) {
-                astilleroAgregaProducto(grupoProducto,idservicio);
-            });
+        success: function({gruposProductos}) {
+            gruposProductos.forEach(grupo => astilleroAgregaProducto(grupo, idservicio))
         }
     });
+
 });
 
 


### PR DESCRIPTION
Antes al intentar agregar un listado de productos en base a un servicio
se rompia el query ya que era una referencia circular rota, se optimizo
un mejor query para hacer la busqueda solo por el grupo de productos con
un leftjoin de sus productos, esto previene que se sobrecargue el
servidor con un query.