### PR TITLE
Limite de fechas de aceptación en cotizaciones

### DIFF
--- a/app/Resources/views/astillero/cotizacion/show.html.twig
+++ b/app/Resources/views/astillero/cotizacion/show.html.twig
@@ -93,15 +93,15 @@
                                         </tr>
                                         <tr>
                                             <th>Fecha inicio</th>
-                                            <td>{% if astilleroCotizacion.fechaLlegada %}{{ astilleroCotizacion.fechaLlegada|date('Y-m-d') }}{% endif %}</td>
+                                            <td>{% if astilleroCotizacion.fechaLlegada %}{{ astilleroCotizacion.fechaLlegada|date('d/m/Y') }}{% endif %}</td>
                                         </tr>
                                         <tr>
                                             <th>Fecha fin</th>
-                                            <td>{% if astilleroCotizacion.fechaSalida %}{{ astilleroCotizacion.fechaSalida|date('Y-m-d') }}{% endif %}</td>
+                                            <td>{% if astilleroCotizacion.fechaSalida %}{{ astilleroCotizacion.fechaSalida|date('d/m/Y') }}{% endif %}</td>
                                         </tr>
                                         <tr>
                                             <th>Fecha cotización</th>
-                                            <td>{% if astilleroCotizacion.fecharegistro %}{{ astilleroCotizacion.fecharegistro|date('Y-m-d H:i:s') }}{% endif %}</td>
+                                            <td>{% if astilleroCotizacion.fecharegistro %}{{ astilleroCotizacion.fecharegistro|date('d/m/Y H:i:s') }}{% endif %}</td>
                                         </tr>
                                         <tr>
                                             <th>Creó la cotización</th>
@@ -147,6 +147,14 @@
                                                 </td>
                                             </tr>
                                         {% endif %}
+                                        <tr>
+                                            <th>Límite aceptación cliente</th>
+                                            <td>
+                                                {% if astilleroCotizacion.limiteValidaCliente %}
+                                                {{ astilleroCotizacion.limiteValidaCliente|date('d/m/Y') }}
+                                                {% endif %}
+                                            </td>
+                                        </tr>
                                         </tbody>
                                     </table>
                                 </div>

--- a/app/Resources/views/combustible/show.html.twig
+++ b/app/Resources/views/combustible/show.html.twig
@@ -105,6 +105,22 @@
                                              <td>{{ pago }}</td>
                                          </tr>
                                      {% endif %}
+                                     <tr>
+                                         <th>Fecha cotización</th>
+                                         <td>
+                                             {% if combustible.fecha %}
+                                                 {{ combustible.fecha|date('d/m/Y H:i:s') }}
+                                             {% endif %}
+                                         </td>
+                                     </tr>
+                                     <tr>
+                                         <th>Límite aceptación cliente</th>
+                                         <td>
+                                             {% if combustible.limiteValidaCliente %}
+                                                 {{ combustible.limiteValidaCliente|date('d/m/Y') }}
+                                             {% endif %}
+                                         </td>
+                                     </tr>
                                      </tbody>
                                  </table>
                              </div>

--- a/app/Resources/views/mail/cotizacion.html.twig
+++ b/app/Resources/views/mail/cotizacion.html.twig
@@ -6,10 +6,12 @@
     </p>
 
     <div class="text-center">
-        <a href="{{ absolute_url(url('clientes_cotizacion', {'token': cotizacion.token })) }}" class="btn"
-           style="background-color: #458FCE">
-            Autorizar
-        </a>
+        {% if cotizacion.token %}
+            <a href="{{ absolute_url(url('clientes_cotizacion', {'token': cotizacion.token })) }}" class="btn"
+               style="background-color: #458FCE">
+                Autorizar
+            </a>
+        {% endif %}
     </div>
 {% endblock body %}
 

--- a/app/Resources/views/marinahumeda/cotizacion/show.html.twig
+++ b/app/Resources/views/marinahumeda/cotizacion/show.html.twig
@@ -121,13 +121,19 @@
                                         {% if marinaHumedaCotizacion.fechaLlegada %}
                                             <tr>
                                                 <th>Fecha llegada</th>
-                                                <td>{{ marinaHumedaCotizacion.fechaLlegada|date('d-m-Y') }}</td>
+                                                <td>{{ marinaHumedaCotizacion.fechaLlegada|date('d/m/Y') }}</td>
                                             </tr>
                                         {% endif %}
                                         {% if marinaHumedaCotizacion.fechaSalida %}
                                             <tr>
                                                 <th>Fecha salida</th>
-                                                <td>{{ marinaHumedaCotizacion.fechaSalida|date('d-m-Y') }}</td>
+                                                <td>{{ marinaHumedaCotizacion.fechaSalida|date('d/m/Y') }}</td>
+                                            </tr>
+                                        {% endif %}
+                                        {% if marinaHumedaCotizacion.fecharegistro %}
+                                            <tr>
+                                                <th>Fecha cotización</th>
+                                                <td>{{ marinaHumedaCotizacion.fecharegistro|date('d/m/Y H:i:s') }}</td>
                                             </tr>
                                         {% endif %}
                                         {% if marinaHumedaCotizacion.slip %}
@@ -185,7 +191,14 @@
                                                 </td>
                                             </tr>
                                         {% endif %}
-
+                                        {% if marinaHumedaCotizacion.limiteValidaCliente %}
+                                            <tr>
+                                                <th>Límite aceptación cliente</th>
+                                                <td>
+                                                    {{ marinaHumedaCotizacion.limiteValidaCliente|date('d/m/Y') }}
+                                                </td>
+                                            </tr>
+                                        {% endif %}
                                         </tbody>
                                     </table>
                                 </div>

--- a/app/Resources/views/valorsistema/edit.html.twig
+++ b/app/Resources/views/valorsistema/edit.html.twig
@@ -54,6 +54,9 @@
                         {{ form_row(edit_form.diasHabilesAstilleroCotizacion )}}
                     </div>
                     <div class="col-sm-6">
+                        {{ form_row(edit_form.diasHabilesCombustible )}}
+                    </div>
+                    <div class="col-sm-6">
                         {{ form_row(edit_form.porcentajeMoratorio )}}
                     </div>
                 </div>

--- a/app/Resources/views/valorsistema/index.html.twig
+++ b/app/Resources/views/valorsistema/index.html.twig
@@ -57,12 +57,16 @@
                                         <td>{{ valor.correo }}</td>
                                     </tr>
                                     <tr>
-                                        <td>Días Hábiles Pago Cotización Marina</td>
+                                        <td>Días Hábiles Cotización Marina Húmeda</td>
                                         <td>{{ valor.diasHabilesMarinaCotizacion }} días</td>
                                     </tr>
                                     <tr>
                                         <td>Días Hábiles Cotización Astillero</td>
                                         <td>{{ valor.diasHabilesAstilleroCotizacion }} días</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Días Hábiles Cotización Combustible</td>
+                                        <td>{{ valor.diasHabilesCombustible }} días</td>
                                     </tr>
                                     <tr>
                                         <td>Mensaje Correo Marina Húmeda</td>

--- a/src/AppBundle/Controller/CombustibleController.php
+++ b/src/AppBundle/Controller/CombustibleController.php
@@ -323,6 +323,14 @@ class CombustibleController extends Controller
                     'tipo' => Correo\Notificacion::TIPO_COMBUSTIBLE
                 ]);
                 $this->enviaCorreoNotificacion($mailer, $notificables, $combustible);
+
+                // Guardar la fecha en la que se valido la cotizacion novonautica y agrega fecha límite para
+                // aceptación por el cliente
+                $sistema = $em->getRepository('AppBundle:ValorSistema')->find(1);
+                $diasCombustible = $sistema->getDiasHabilesCombustible();
+                $combustible
+                    ->setRegistroValidaNovo(new \DateTimeImmutable())
+                    ->setLimiteValidaCliente((new \DateTime('now'))->modify('+ '.$diasCombustible.' day'));
             }
             if ($combustible->getValidacliente() === 2) {
                 // Guardar la fecha en la que se valido la cotizacion por el cliente

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -77,10 +77,12 @@ class DefaultController extends Controller
         if (null === $cotizacion || $cotizacion->getCliente() !== $this->getUser()) {
             throw new NotFoundHttpException('No se encontro la cotización');
         }
-
+        if((new \DateTime('now'))->setTime(0,0,0,0) > $cotizacion->getLimiteValidaCliente()->setTime(0,0,0,0)){
+            throw new NotFoundHttpException('Cotización caducada');
+        }
         $form = $this->createFormBuilder([])
             ->add('action', ChoiceType::class, [
-                'label' => 'Seleccione una opcion para continuar',
+                'label' => 'Seleccione una opción para continuar:',
                 'expanded' => true,
                 'data' => true,
                 'choices' => [

--- a/src/AppBundle/Controller/MarinaHumedaCotizacionController.php
+++ b/src/AppBundle/Controller/MarinaHumedaCotizacionController.php
@@ -317,11 +317,20 @@ class MarinaHumedaCotizacionController extends Controller
                 ]);
 
                 $this->enviaCorreoNotificacion($mailer, $notificables, $marinaHumedaCotizacion);
+
+                // Guardar la fecha en la que se valido la cotización por novonautica y agrega fecha límite para
+                // aceptación por el cliente
+                $sistema = $em->getRepository('AppBundle:ValorSistema')->find(1);
+                $diasMarina = $sistema->getDiasHabilesMarinaCotizacion();
+                $marinaHumedaCotizacion
+                    ->setRegistroValidaNovo(new \DateTimeImmutable())
+                    ->setLimiteValidaCliente((new \DateTime('now'))->modify('+ '.$diasMarina.' day'));
             }
 
             if ($marinaHumedaCotizacion->getValidacliente() === 2) {
                 // Guardar la fecha en la que se valido la cotizacion por el cliente
-                $marinaHumedaCotizacion->setRegistroValidaCliente(new \DateTimeImmutable());
+                $marinaHumedaCotizacion
+                    ->setRegistroValidaCliente(new \DateTimeImmutable());
 
                 // Quien valido por el cliente
                 $marinaHumedaCotizacion->setQuienAcepto($this->getUser()->getNombre());

--- a/src/AppBundle/Entity/AstilleroCotizacion.php
+++ b/src/AppBundle/Entity/AstilleroCotizacion.php
@@ -199,6 +199,13 @@ class AstilleroCotizacion
     private $validacliente;
 
     /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="limite_valida_cliente", type="datetime", nullable=true)
+     */
+    private $limiteValidaCliente;
+
+    /**
      * Se refiere a un cliente que haya aceptado la cotizacion o a un usuario de novonautica
      *
      * @var string
@@ -1196,5 +1203,29 @@ class AstilleroCotizacion
     public function getDescuentototal()
     {
         return $this->descuentototal;
+    }
+
+    /**
+     * Set limiteValidaCliente.
+     *
+     * @param \DateTime|null $limiteValidaCliente
+     *
+     * @return AstilleroCotizacion
+     */
+    public function setLimiteValidaCliente($limiteValidaCliente = null)
+    {
+        $this->limiteValidaCliente = $limiteValidaCliente;
+
+        return $this;
+    }
+
+    /**
+     * Get limiteValidaCliente.
+     *
+     * @return \DateTime|null
+     */
+    public function getLimiteValidaCliente()
+    {
+        return $this->limiteValidaCliente;
     }
 }

--- a/src/AppBundle/Entity/Combustible.php
+++ b/src/AppBundle/Entity/Combustible.php
@@ -194,6 +194,13 @@ class Combustible
     private $validacliente;
 
     /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="limite_valida_cliente", type="datetime", nullable=true)
+     */
+    private $limiteValidaCliente;
+
+    /**
      * @var string
      *
      * @ORM\Column(name="notasnovo", type="text", nullable=true)
@@ -1260,5 +1267,29 @@ class Combustible
     public function getRegistroPagoCompletado()
     {
         return $this->registroPagoCompletado;
+    }
+
+    /**
+     * Set limiteValidaCliente.
+     *
+     * @param \DateTime|null $limiteValidaCliente
+     *
+     * @return Combustible
+     */
+    public function setLimiteValidaCliente($limiteValidaCliente = null)
+    {
+        $this->limiteValidaCliente = $limiteValidaCliente;
+
+        return $this;
+    }
+
+    /**
+     * Get limiteValidaCliente.
+     *
+     * @return \DateTime|null
+     */
+    public function getLimiteValidaCliente()
+    {
+        return $this->limiteValidaCliente;
     }
 }

--- a/src/AppBundle/Entity/MarinaHumedaCotizacion.php
+++ b/src/AppBundle/Entity/MarinaHumedaCotizacion.php
@@ -153,6 +153,13 @@ class MarinaHumedaCotizacion
     private $validacliente;
 
     /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="limite_valida_cliente", type="datetime", nullable=true)
+     */
+    private $limiteValidaCliente;
+
+    /**
      * @var string
      *
      * @ORM\Column(name="quien_acepto", type="string", length=100, nullable=true)
@@ -1324,5 +1331,29 @@ class MarinaHumedaCotizacion
     public function getMoratoriaTotal()
     {
         return $this->moratoriaTotal;
+    }
+
+    /**
+     * Set limiteValidaCliente.
+     *
+     * @param \DateTime|null $limiteValidaCliente
+     *
+     * @return MarinaHumedaCotizacion
+     */
+    public function setLimiteValidaCliente($limiteValidaCliente = null)
+    {
+        $this->limiteValidaCliente = $limiteValidaCliente;
+
+        return $this;
+    }
+
+    /**
+     * Get limiteValidaCliente.
+     *
+     * @return \DateTime|null
+     */
+    public function getLimiteValidaCliente()
+    {
+        return $this->limiteValidaCliente;
     }
 }

--- a/src/AppBundle/Entity/ValorSistema.php
+++ b/src/AppBundle/Entity/ValorSistema.php
@@ -96,6 +96,13 @@ class ValorSistema
     private $diasHabilesAstilleroCotizacion;
 
     /**
+     * @var int
+     *
+     * @ORM\Column(name="dias_habiles_combustible", type="integer")
+     */
+    private $diasHabilesCombustible;
+
+    /**
      * @var float
      * @Assert\NotBlank(
      *     message="El porcentaje moratorio no puede quedar vacío"
@@ -511,5 +518,29 @@ class ValorSistema
     public function getFolioCombustible()
     {
         return $this->folioCombustible;
+    }
+
+    /**
+     * Set diasHabilesCombustible.
+     *
+     * @param int $diasHabilesCombustible
+     *
+     * @return ValorSistema
+     */
+    public function setDiasHabilesCombustible($diasHabilesCombustible)
+    {
+        $this->diasHabilesCombustible = $diasHabilesCombustible;
+
+        return $this;
+    }
+
+    /**
+     * Get diasHabilesCombustible.
+     *
+     * @return int
+     */
+    public function getDiasHabilesCombustible()
+    {
+        return $this->diasHabilesCombustible;
     }
 }

--- a/src/AppBundle/Form/ValorSistemaType.php
+++ b/src/AppBundle/Form/ValorSistemaType.php
@@ -41,12 +41,17 @@ class ValorSistemaType extends AbstractType
                 'label' => 'Folio combustible'
             ])
             ->add('diasHabilesMarinaCotizacion',TextType::class,[
-                'label' => 'Días hábiles pago de cotización marina húmeda',
+                'label' => 'Días hábiles cotización marina húmeda',
                 'attr' => ['class' => 'esdecimal'],
                 'required' => false,
             ])
             ->add('diasHabilesAstilleroCotizacion',TextType::class,[
                 'label' => 'Días hábiles cotización astillero',
+                'attr' => ['class' => 'esdecimal'],
+                'required' => false,
+            ])
+            ->add('diasHabilesCombustible',TextType::class,[
+                'label' => 'Días hábiles cotización combustible',
                 'attr' => ['class' => 'esdecimal'],
                 'required' => false,
             ])


### PR DESCRIPTION
Agregado variable del sistema de días hábiles para aceptación de cotización combustible.
Agregado fecha de cotización en vista marina humeda y combustible.
Agregado fecha limite aceptación cotización en entidades astillero, marina y combustible. El valor se basa en variables del sistema respectivas.
Agregado fecha límite en vistas de cotizaciónes antes mencionadas.
En el correo para aceptación del cliente agregado condición en caso de no tener token no mostrar boton de aceptar (funciona en caso de reenvio de correo desde el sistema).
En ruta del sistema desde donde el cliente acepta cotizaciones agregado condición para evitar que ingrese a aceptar la cotización en caso de pasarse de la fecha límite.
Reparado astillero nueva cotización al guardar
Fixed #323 