### PR TITLE
Remocion de listeners de reportes

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -52,22 +52,6 @@ services:
         tags:
             - { name: doctrine.orm.entity_listener }
 
-#    AppBundle\EventListener\ReportePagoListener:
-#        tags:
-#            - { name: doctrine.event_subscriber }
-
-    AppBundle\EventListener\ReporteAstilleroListener:
-        tags:
-            - { name: doctrine.event_subscriber }
-
-    AppBundle\EventListener\ReporteMarinaListener:
-        tags:
-            - { name: doctrine.event_subscriber }
-
-    AppBundle\EventListener\ReporteSolicitudListener:
-        tags:
-            - { name: doctrine.event_subscriber }
-
     AppBundle\DataTables\:
         resource: '../../src/AppBundle/DataTables'
         autowire: true


### PR DESCRIPTION
Ahora ya no se ocupan los reportes y por ende sus listener que arruinaban la base de datos