### PR TITLE
Marina adicionales - Tipo cotización y moneda

### DIFF
--- a/app/Resources/views/marinahumeda/cotizacionadicional/edit.html.twig
+++ b/app/Resources/views/marinahumeda/cotizacionadicional/edit.html.twig
@@ -107,6 +107,9 @@
                         <div role="tabpanel" class="tab-pane" id="servicios">
                             <div class="row">
                                 <div class="col-sm-4">
+                                    {{ form_row(edit_form.tipo) }}
+                                </div>
+                                <div class="col-sm-4">
                                     <label>Dolar:</label>
                                     {{ form_widget(edit_form.dolar) }}
                                 </div>

--- a/app/Resources/views/marinahumeda/cotizacionadicional/new.html.twig
+++ b/app/Resources/views/marinahumeda/cotizacionadicional/new.html.twig
@@ -30,13 +30,13 @@
                     <div class="tab-content">
                         <div role="tabpanel" class="tab-pane active" id="generales">
                             <div class="row">
-                                <div class="col-sm-3">
+                                <div class="col-sm-4">
                                     {{ form_row(form.cliente) }}
                                     <div id="info-cliente">
 
                                     </div>
                                 </div>
-                                <div class="col-sm-3">
+                                <div class="col-sm-4">
                                     {{ form_errors(form.barco) }}
                                     <div class="radio buscabarcomh">
                                         {{ form_label(form.barco) }}
@@ -49,6 +49,9 @@
                         </div>
                         <div role="tabpanel" class="tab-pane" id="servicios">
                             <div class="row">
+                                <div class="col-sm-4">
+                                    {{ form_row(form.tipo) }}
+                                </div>
                                 <div class="col-sm-4">
                                     <label>Dolar:</label>
                                     {{ form_widget(form.dolar) }}

--- a/app/Resources/views/marinahumeda/cotizacionadicional/show.html.twig
+++ b/app/Resources/views/marinahumeda/cotizacionadicional/show.html.twig
@@ -24,10 +24,10 @@
                         <a href="#generales" aria-controls="generales" role="tab" data-toggle="tab">Generales</a>
                     </li>
                     <li role="presentation">
-                        <a href="#totales" aria-controls="totales" role="tab" data-toggle="tab">Totales (USD)</a>
+                        <a href="#totales" aria-controls="totales" role="tab" data-toggle="tab">Totales (MXN)</a>
                     </li>
                     <li role="presentation">
-                        <a href="#totalesmxn" aria-controls="totalesmxn" role="tab" data-toggle="tab">Totales (MXN)</a>
+                        <a href="#totalesusd" aria-controls="totalesusd" role="tab" data-toggle="tab">Totales (USD)</a>
                     </li>
                 </ul>
                 <div class="tab-content">
@@ -114,6 +114,12 @@
                     </div>
                     <div role="tabpanel" class="tab-pane" id="totales">
                         <div class="row">
+                            <div class="col-sm-12">
+                                <span>Tipo de cotización:</span>
+                                {{ marinaHumedaCotizacionAdicional.tipoNombre }}
+                            </div>
+                        </div>
+                        <div class="row">
                             <div class="col-sm-12 text-right">
                                 <span>Tipo de cambio:</span>
                                 <div id="tipocambio" class="">{{ (marinaHumedaCotizacionAdicional.dolar/100)|number_format(2) }}
@@ -123,7 +129,7 @@
                         </div>
                         <div class="row">
                             <div class="col-sm-12">
-                                <small>Precios en USD</small>
+                                <small>Precios en MXN</small>
                             </div>
                         </div>
                         <div class="row">
@@ -146,10 +152,10 @@
                                                 <td>{{ servicio.cantidad }}</td>
                                                 <td>{{ servicio.marinahumedaservicio }}</td>
                                                 <td>{{ servicio.marinahumedaservicio.unidad }}</td>
-                                                <td>$ {{ (servicio.precio/100)|number_format(2) }}</td>
-                                                <td>$ {{ (servicio.subtotal/100)|number_format(2) }}</td>
-                                                <td>$ {{ (servicio.iva/100)|number_format(2) }}</td>
-                                                <td>$ {{ (servicio.total/100)|number_format(2) }}</td>
+                                                <td>$ {{ (servicio.precio/100)|number_format(2) }} <small>MXN</small></td>
+                                                <td>$ {{ (servicio.subtotal/100)|number_format(2) }} <small>MXN</small></td>
+                                                <td>$ {{ (servicio.iva/100)|number_format(2) }} <small>MXN</small></td>
+                                                <td>$ {{ (servicio.total/100)|number_format(2) }} <small>MXN</small></td>
                                             </tr>
                                     {% endfor %}
                                     </tbody>
@@ -173,7 +179,7 @@
                                 <p class="letra-azul">Sub-Total:</p>
                                 <p>
                                     $ <span id="gransubtot">{{ (marinaHumedaCotizacionAdicional.subtotal/100)|number_format(2,'.',',') }}</span>
-                                    <span class="tipo-letra2">USD</span>
+                                    <span class="tipo-letra2">MXN</span>
                                 </p>
                             </div>
                         </div>
@@ -187,7 +193,7 @@
                                 <p class="letra-azul">I.V.A:</p>
                                 <p>
                                     $ <span>{{ (marinaHumedaCotizacionAdicional.ivatotal/100)|number_format(2,'.',',') }}</span>
-                                    <span class="tipo-letra2">USD</span>
+                                    <span class="tipo-letra2">MXN</span>
                                 </p>
                             </div>
                         </div>
@@ -201,7 +207,7 @@
                                 <p class="letra-azul">Total:</p>
                                 <p>
                                     $ <span>{{ (marinaHumedaCotizacionAdicional.total/100)|number_format(2,'.',',') }}</span>
-                                    <span class="tipo-letra2">USD</span>
+                                    <span class="tipo-letra2">MXN</span>
                                 </p>
                             </div>
                         </div>
@@ -211,7 +217,13 @@
                             </div>
                         </div>
                     </div>
-                    <div role="tabpanel" class="tab-pane" id="totalesmxn">
+                    <div role="tabpanel" class="tab-pane" id="totalesusd">
+                        <div class="row">
+                            <div class="col-sm-12">
+                                <span>Tipo de cotización:</span>
+                                {{ marinaHumedaCotizacionAdicional.tipoNombre }}
+                            </div>
+                        </div>
                         <div class="row">
                             <div class="col-sm-12 text-right">
                                 <span>Tipo de cambio:</span>
@@ -222,7 +234,7 @@
                         </div>
                         <div class="row">
                             <div class="col-sm-12">
-                                <small>Precios en MXN</small>
+                                <small>Precios en USD</small>
                             </div>
                         </div>
                         <div class="row">
@@ -273,7 +285,7 @@
                                 <p class="letra-azul">Sub-Total:</p>
                                 <p>
                                     $ <span id="gransubtot">{{ ((marinaHumedaCotizacionAdicional.subtotal/100) * (marinaHumedaCotizacionAdicional.dolar/100))|number_format(2) }}</span>
-                                    <span class="tipo-letra2">MXN</span>
+                                    <span class="tipo-letra2">USD</span>
                                 </p>
                             </div>
                         </div>
@@ -287,7 +299,7 @@
                                 <p class="letra-azul">I.V.A:</p>
                                 <p>
                                     $ <span id="graniva">{{ ((marinaHumedaCotizacionAdicional.ivatotal/100) *( marinaHumedaCotizacionAdicional.dolar/100))|number_format(2) }}</span>
-                                    <span class="tipo-letra2">MXN</span>
+                                    <span class="tipo-letra2">USD</span>
                                 </p>
                             </div>
                         </div>
@@ -301,7 +313,7 @@
                                 <p class="letra-azul">Total:</p>
                                 <p>
                                     $ <span id="grantot">{{ ((marinaHumedaCotizacionAdicional.total/100) * (marinaHumedaCotizacionAdicional.dolar/100))|number_format(2) }}</span>
-                                    <span class="tipo-letra2">MXN</span>
+                                    <span class="tipo-letra2">USD</span>
                                 </p>
                             </div>
                         </div>

--- a/app/Resources/views/marinahumeda/servicio/index.html.twig
+++ b/app/Resources/views/marinahumeda/servicio/index.html.twig
@@ -31,7 +31,7 @@
                                 <td>{{ i }}</td>
                                 <td>{{ marinaHumedaServicio.nombre }}</td>
                                 <td>{{ marinaHumedaServicio.unidad }}</td>
-                                <td>$ {{ (marinaHumedaServicio.precio/100)|number_format(2) }}</td>
+                                <td>$ {{ (marinaHumedaServicio.precio/100)|number_format(2) }} <small>MXN</small></td>
                                 <td>
                                     <a class="btn btn-azul" href="{{ path('marina-humeda-servicio_edit', { 'id': marinaHumedaServicio.id }) }}">
                                         Editar

--- a/src/AppBundle/DataTables/MHAdicionalDataTable.php
+++ b/src/AppBundle/DataTables/MHAdicionalDataTable.php
@@ -102,9 +102,9 @@ class MHAdicionalDataTable extends AbstractDataTableHandler
                 $adicional->getId(),
                 $adicional->getCliente()->getNombre(),
                 $adicional->getBarco()->getNombre(),
-                '$ '.number_format($adicional->getSubtotal()/100,2).' USD',
-                '$ '.number_format($adicional->getIvatotal()/100,2).' USD',
-                '$ '.number_format($adicional->getTotal()/100,2).' USD',
+                '$ '.number_format($adicional->getSubtotal()/100,2).' MXN',
+                '$ '.number_format($adicional->getIvatotal()/100,2).' MXN',
+                '$ '.number_format($adicional->getTotal()/100,2).' MXN',
                 $adicional->getFecharegistro()?$adicional->getFecharegistro()->format('d/m/Y'):'',
                 $adicional->getId()
             ];

--- a/src/AppBundle/Entity/MarinaHumedaCotizacionAdicional.php
+++ b/src/AppBundle/Entity/MarinaHumedaCotizacionAdicional.php
@@ -13,6 +13,10 @@ use Doctrine\Common\Collections\ArrayCollection;
  */
 class MarinaHumedaCotizacionAdicional
 {
+    const EXENTO = 1;
+    const TASA_CERO = 2;
+    const IVA = 3;
+
     /**
      * @var int
      *
@@ -97,6 +101,19 @@ class MarinaHumedaCotizacionAdicional
      * @ORM\OneToMany(targetEntity="AppBundle\Entity\MarinaHumedaCotizaServicios", mappedBy="marinahumedacotizacionadicional",cascade={"persist"})
      */
     private $mhcservicios;
+
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="tipo", type="smallint")
+     */
+    private $tipo;
+
+    private static $tipoList = [
+        MarinaHumedaCotizacionAdicional::EXENTO => 'Exento',
+        MarinaHumedaCotizacionAdicional::TASA_CERO => 'Tasa cero',
+        MarinaHumedaCotizacionAdicional::IVA => 'Iva'
+    ];
 
     /**
      * Constructor
@@ -389,5 +406,36 @@ class MarinaHumedaCotizacionAdicional
     public function getMhcservicios()
     {
         return $this->mhcservicios;
+    }
+
+
+    /**
+     * @return int
+     */
+    public function getTipo()
+    {
+        return $this->tipo;
+    }
+
+    /**
+     * @param int $tipo
+     */
+    public function setTipo($tipo)
+    {
+        $this->tipo = $tipo;
+    }
+
+    public static function getTipoList()
+    {
+        return self::$tipoList;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTipoNombre()
+    {
+        if (null === $this->tipo) { return null; }
+        return self::$tipoList[$this->tipo];
     }
 }

--- a/src/AppBundle/Form/MarinaHumedaCotizaServiciosAdicionalesType.php
+++ b/src/AppBundle/Form/MarinaHumedaCotizaServiciosAdicionalesType.php
@@ -35,25 +35,25 @@ class MarinaHumedaCotizaServiciosAdicionalesType extends AbstractType
             ])
             ->add('precio',MoneyType::class,[
                 'attr' => ['class' => 'esdecimal', 'autocomplete'=>'off', 'readonly' => true],
-                'currency' => 'USD',
+                'currency' => 'MXN',
                 'divisor' => 100,
                 'grouping' => true,
             ])
             ->add('subtotal', MoneyType::class,[
                 'attr' => ['class' => 'esdecimal', 'autocomplete'=>'off', 'readonly' => true],
-                'currency' => 'USD',
+                'currency' => 'MXN',
                 'divisor' => 100,
                 'grouping' => true,
             ])
             ->add('iva', MoneyType::class,[
                 'attr' => ['class' => 'esdecimal', 'autocomplete'=>'off', 'readonly' => true],
-                'currency' => 'USD',
+                'currency' => 'MXN',
                 'divisor' => 100,
                 'grouping' => true,
             ])
             ->add('total', MoneyType::class,[
                 'attr' => ['class' => 'esdecimal', 'autocomplete'=>'off', 'readonly' => true],
-                'currency' => 'USD',
+                'currency' => 'MXN',
                 'divisor' => 100,
                 'grouping' => true,
             ])

--- a/src/AppBundle/Form/MarinaHumedaCotizacionAdicionalType.php
+++ b/src/AppBundle/Form/MarinaHumedaCotizacionAdicionalType.php
@@ -4,6 +4,8 @@ namespace AppBundle\Form;
 
 use AppBundle\Entity\Cliente;
 
+use AppBundle\Entity\MarinaHumedaCotizacionAdicional;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
@@ -42,7 +44,7 @@ class MarinaHumedaCotizacionAdicionalType extends AbstractType
                 'label' => 'IVA %'
             ])
             ->add('subtotal', MoneyType::class,[
-                'currency' => 'USD',
+                'currency' => 'MXN',
                 'divisor' => 100,
                 'grouping' => true,
                 'label' => 'Sub-Total',
@@ -50,7 +52,7 @@ class MarinaHumedaCotizacionAdicionalType extends AbstractType
                 'attr' => ['readonly' => true]
             ])
             ->add('ivatotal', MoneyType::class,[
-                'currency' => 'USD',
+                'currency' => 'MXN',
                 'divisor' => 100,
                 'grouping' => true,
                 'label' => 'IVA',
@@ -58,7 +60,7 @@ class MarinaHumedaCotizacionAdicionalType extends AbstractType
                 'attr' => ['readonly' => true]
             ])
             ->add('total', MoneyType::class,[
-                'currency' => 'USD',
+                'currency' => 'MXN',
                 'divisor' => 100,
                 'grouping' => true,
                 'label_attr' => ['class' => 'letra-azul tipo-letra1'],
@@ -71,6 +73,9 @@ class MarinaHumedaCotizacionAdicionalType extends AbstractType
                 'allow_delete' => true,
                 'prototype' => true,
                 'by_reference' => false
+            ])
+            ->add('tipo', ChoiceType::class, [
+                'choices' => array_flip(MarinaHumedaCotizacionAdicional::getTipoList())
             ]);
 
         $formModifier = function (FormInterface $form, Cliente $cliente = null) {

--- a/src/AppBundle/Form/MarinaHumedaServicioType.php
+++ b/src/AppBundle/Form/MarinaHumedaServicioType.php
@@ -27,7 +27,7 @@ class MarinaHumedaServicioType extends AbstractType
             ->add('precio',MoneyType::class,[
                 'required'=>false,
                 'attr' => ['class' => 'esdecimal'],
-                'currency' => 'USD',
+                'currency' => 'MXN',
                 'divisor' => 100,
                 'grouping' => true,
             ]);


### PR DESCRIPTION
Agregado campo para indicar el tipo de cotización. Se cambiaron los formularios y vistas para indicar que las cantidades están en pesos. El catalogo de servicios también está en pesos.
Fixed #359, fixed #422 