### PR TITLE
Reparado ingresar días cotización astillero

### DIFF
--- a/app/Resources/views/security/login.html.twig
+++ b/app/Resources/views/security/login.html.twig
@@ -54,7 +54,7 @@
                                     <a href="{{ path('password_forgot') }}">¿Olvidaste tu contraseña?</a>
                                 </div>
                                 <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">
-                                <button type="submit" class="btn boton-login">Entrar</button>
+                                <button type="submit" class="btn boton-login no-loading">Entrar</button>
                             </form>
                         </div>
                     </div>

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1114,13 +1114,13 @@ $('#appbundle_astillerocotizacion_fechaSalida').on("change", function () {
      calculaSubtotalesAstillero($('#fila_estadia'));
  }
 $('#appbundle_astillerocotizacion_diasEstadia').keyup(function () {
-    // var dias = $(this).val();
-    // var nueva_estadia_cantidad = dias * $("#estadia_cantidad").data('eslora');
-    // $("#estadia_cantidad").data('dias', dias);
-    // $("#estadia_cantidad").data('valor', nueva_estadia_cantidad);
-    // $("#estadia_cantidad").html(dias + ' (pie por día)');
-    // calculaSubtotalesAstillero($('#fila_estadia'));
-    calculaDiasEstadiaAstillero();
+    var dias = $(this).val();
+    var nueva_estadia_cantidad = dias * $("#estadia_cantidad").data('eslora');
+    $("#estadia_cantidad").data('dias', dias);
+    $("#estadia_cantidad").data('valor', nueva_estadia_cantidad);
+    $("#estadia_cantidad").html(dias + ' (pie por día)');
+    calculaSubtotalesAstillero($('#fila_estadia'));
+    //calculaDiasEstadiaAstillero();
 });
 $('#appbundle_astillerocotizacion_descuento').keyup(function (){
     calculaTotalesAstillero();


### PR DESCRIPTION
Corregido error que no permitia ingresar días de estadía directamente en el input de una cotización de astillero. En el login ya no aparece la palabra cargando cuando le das clic.