### PR TITLE
Menú título proveedor/contratista

### DIFF
--- a/app/Resources/views/estructura/sidebar.html.twig
+++ b/app/Resources/views/estructura/sidebar.html.twig
@@ -591,7 +591,7 @@
             {% if is_granted('ROLE_PROVEEDOR') %}
                 <li class="treeview {{ path.check('proveedor_') }}">
                     <a href="#">
-                        <i class="fa fa-cube"></i> Proveedor/Contratista
+                        <i class="fa fa-cube"></i> <span>Proveedor/Contratista</span>
                         <span class="pull-right-container"><i
                                     class="fa fa-angle-left pull-right"></i></span>
                     </a>


### PR DESCRIPTION
Reparado error en menú título proveedor/contratista, no se ocultaba el texto al minimizarlo