### PR TITLE
JRF Marine Divisa y Combustible campos nulos

### DIFF
--- a/app/Resources/views/combustible/new.html.twig
+++ b/app/Resources/views/combustible/new.html.twig
@@ -427,26 +427,36 @@
                 url: url,
                 dataType: 'json',
                 success: function (barco) {
-                    var cliente = barco.cliente;
+                    let barcoModeloAux = barco.modelo?barco.modelo:'';
+                    let barcoEsloraAux = barco.eslora?barco.eslora:0;
+                    let mangaAux = barco.manga?barco.manga:'';
+                    let nombreCapitanAux = barco.nombreCapitan?barco.nombreCapitan:'';
+                    let telefonoCapitanAux = barco.telefonoCapitan?barco.telefonoCapitan:'';
+                    let correoCapitanAux = barco.correoCapitan?barco.correoCapitan:'';
+                    let cliente = barco.cliente;
+                    let clienteNombreAux = cliente.nombre?cliente.nombre:'';
+                    let clienteCorreoAux = cliente.correo?cliente.correo:'';
+                    let clienteTelefonoAux = cliente.telefono?cliente.telefono:'';
+                    let clienteDireccionAux = cliente.direccion?cliente.direccion:'';
                     var htmlBarco = "<label>Modelo</label>" +
-                        "<div class='info-input'>" + barco.modelo + "</div>" +
+                        "<div class='info-input'>" + barcoModeloAux + "</div>" +
                         "<label>Eslora</label>" +
-                        "<div id='eslora' class='info-input' data-valor='" + barco.eslora + "'>" + barco.eslora + "</div>" +
-                        "<label>Manga</label>" + "<div class='info-input'>" + barco.manga + "</div>" +
+                        "<div id='eslora' class='info-input' data-valor='" + barcoEsloraAux + "'>" + barcoEsloraAux + "</div>" +
+                        "<label>Manga</label>" + "<div class='info-input'>" + mangaAux + "</div>" +
                         "<label>Nombre del capitán</label>" +
-                        "<div class='info-input'>" + barco.nombreCapitan + "</div>" +
+                        "<div class='info-input'>" + nombreCapitanAux + "</div>" +
                         "<label>Teléfono del capitán</label>" +
-                        "<div class='info-input'>" + barco.telefonoCapitan + "</div>" +
+                        "<div class='info-input'>" + telefonoCapitanAux + "</div>" +
                         "<label>Correo del capitán</label>" +
-                        "<div class='info-input'>" + barco.correoCapitan + "</div>";
+                        "<div class='info-input'>" + correoCapitanAux + "</div>";
                     var htmlCliente = "<label>Cliente</label>" +
-                        "<div class='info-input'>" + cliente.nombre + "</div>" +
+                        "<div class='info-input'>" + clienteNombreAux + "</div>" +
                         "<label>Correo electrónico</label>" +
-                        "<div class='info-input'>" + cliente.correo + "</div>" +
+                        "<div class='info-input'>" + clienteCorreoAux + "</div>" +
                         "<label>Número de teléfono</label>" +
-                        "<div class='info-input'>" + cliente.telefono + "</div>" +
+                        "<div class='info-input'>" + clienteTelefonoAux + "</div>" +
                         "<label>Dirección</label>" +
-                        "<div class='info-input'>" + cliente.direccion + "</div>";
+                        "<div class='info-input'>" + clienteDireccionAux + "</div>";
                     $("#info-barco").append(htmlBarco);
                     $("#info-cliente").append(htmlCliente);
                     $('#loading').hide();

--- a/app/Resources/views/jrfmarine/producto/index.html.twig
+++ b/app/Resources/views/jrfmarine/producto/index.html.twig
@@ -48,6 +48,9 @@
         .percent-input + .input-group-addon {
             border-radius: 0 17px 17px 0 !important;
         }
+        .pr-0{
+            padding-right: 0px;
+        }
     </style>
 {% endblock %}
 
@@ -85,8 +88,14 @@
                             <div class="panel-body" style="min-height: initial">
                                 {{ form_start(form) }}
                                 {{ form_row(form.nombre) }}
-                                {{ form_row(form.precio) }}
-
+                                <div class="row">
+                                    <div class="col-sm-8 pr-0">
+                                        {{ form_row(form.precio) }}
+                                    </div>
+                                    <div class="col-sm-4">
+                                        {{ form_row(form.divisa) }}
+                                    </div>
+                                </div>
                                 {{ form_row(form.marca) }}
                                 {{ form_row(form.categoria) }}
                                 {{ form_row(form.subcategoria) }}

--- a/src/AppBundle/DataTables/JRFMarine/ProductoDataTable.php
+++ b/src/AppBundle/DataTables/JRFMarine/ProductoDataTable.php
@@ -91,7 +91,7 @@ class ProductoDataTable extends AbstractDataTableHandler
 
             $results->data[] = [
                 $producto->getNombre(),
-                '$'.number_format(($producto->getPrecio() / 100), 2),
+                '$'.number_format(($producto->getPrecio() / 100), 2).' <small>'.($producto->getDivisaNombre()??'').'</small>',
                 $categoria->getNombre().' / '.$subcategoria->getNombre(),
                 $marca->getNombre(),
                 $producto->getImagen(),

--- a/src/AppBundle/Entity/JRFMarine/Producto.php
+++ b/src/AppBundle/Entity/JRFMarine/Producto.php
@@ -19,6 +19,9 @@ use Vich\UploaderBundle\Mapping\Annotation as Vich;
  */
 class Producto
 {
+    const DIVISA_MXN = 1;
+    const DIVISA_USD = 2;
+
     /**
      * @var int
      *
@@ -41,6 +44,18 @@ class Producto
      * @ORM\Column(name="precio", type="bigint")
      */
     private $precio;
+
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="divisa", type="smallint")
+     */
+    private $divisa;
+
+    private static $divisaList = [
+      Producto::DIVISA_MXN => 'MXN',
+      Producto::DIVISA_USD => 'USD',
+    ];
 
     /**
      * @var string
@@ -399,4 +414,36 @@ class Producto
     {
         return $this->subcategoria;
     }
+
+    /**
+     * @param int $divisa
+     */
+    public function setDivisa($divisa)
+    {
+        $this->divisa = $divisa;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDivisa()
+    {
+        if (null === $this->divisa) { return null; }
+        return $this->divisa;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDivisaNombre()
+    {
+        if (null === $this->divisa || 0 === $this->divisa) { return null; }
+        return self::$divisaList[$this->divisa];
+    }
+
+    public static function getDivisaList()
+    {
+        return self::$divisaList;
+    }
+
 }

--- a/src/AppBundle/Form/JRFMarine/ProductoType.php
+++ b/src/AppBundle/Form/JRFMarine/ProductoType.php
@@ -11,6 +11,7 @@ use AppBundle\Entity\JRFMarine\Producto;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -49,10 +50,16 @@ class ProductoType extends AbstractType
             MoneyType::class,
             [
                 'divisor' => 100,
-                'currency' => 'MXN',
+                'currency' => 'USD',
             ]
         );
-
+        $builder->add(
+            'divisa',
+            ChoiceType::class,
+            [
+                'choices' => array_flip(Producto::getDivisaList())
+            ]
+        );
         $builder->add(
             'codigoBarras',
             TextType::class,


### PR DESCRIPTION
JRF Marine agregado divisa seleccionable en formulario de captura de productos, se refleja en la tabla del listado junto al precio. Vista combustible arreglado que ahora se muestre campos vacíos o en cero en lugar del texto null cuando no hay algún dato.