### PR TITLE
Error#548 Fixes Error 500 en pdf & preview, Cancelacion y liberacion de cotizacion con su factura

### DIFF
--- a/app/Resources/views/contabilidad/facturacion/pdf/factura.html.twig
+++ b/app/Resources/views/contabilidad/facturacion/pdf/factura.html.twig
@@ -24,10 +24,17 @@
 <div class="container-fluid">
     <div id="header" class="row">
         <div class="col-xs-4 text-center">
+            {% if logoExists %}
             <img src="{{ app.request.scheme ~ '://' ~ app.request.httpHost ~ asset('uploads/facturacion/emisor/logos/') ~ factura.emisor.logo }}"
                  alt="" class="img-responsive center-block"
                  style="max-height: 150px;"
             >
+            {% else %}
+                <img src="{{ app.request.scheme ~ '://' ~ app.request.httpHost ~ asset('img/image-not-found.jpg') }}"
+                     alt="" class="img-responsive center-block"
+                     style="max-height: 150px;"
+                >
+            {% endif %}
         </div>
         <div class="col-xs-4">
             <h4 style="font-weight: bold;margin-top: 0">{{ factura.emisor.nombre }}</h4>

--- a/app/Resources/views/contabilidad/facturacion/pdf/preview.html.twig
+++ b/app/Resources/views/contabilidad/facturacion/pdf/preview.html.twig
@@ -24,10 +24,17 @@
 <div class="container-fluid">
     <div id="header" class="row">
         <div class="col-xs-4 text-center">
-            <img src="{{ app.request.scheme ~ '://' ~ app.request.httpHost ~ asset('uploads/facturacion/emisor/logos/') ~ factura.emisor.logo }}"
-                 alt="" class="img-responsive center-block"
-                 style="max-height: 150px;"
-            >
+            {% if logoExists %}
+                <img src="{{ app.request.scheme ~ '://' ~ app.request.httpHost ~ asset('uploads/facturacion/emisor/logos/') ~ factura.emisor.logo }}"
+                     alt="" class="img-responsive center-block"
+                     style="max-height: 150px;"
+                >
+            {% else %}
+                <img src="{{ app.request.scheme ~ '://' ~ app.request.httpHost ~ asset('img/image-not-found.jpg') }}"
+                     alt="" class="img-responsive center-block"
+                     style="max-height: 150px;"
+                >
+            {% endif %}
         </div>
         <div class="col-xs-4">
             <h4 style="font-weight: bold;margin-top: 0">{{ factura.emisor.nombre }}</h4>


### PR DESCRIPTION
El problema al intentar visualizar pdf & preview es que el generador del PDF intentaba localizar los archivos de imagenes de las empresas, el logo, al no encontrarlo arroja un error 500 porque no puede procesar el PDF, al final decidi hacer una verificacion para ver si existe y no ocurra este problema, aunque es muy improbable que pase, ya que las empresas siempre tienen asignada una imagen.

Tambien como habias mencionado, la cotizacion de la que se genera la factura no se liberaba al cancelar la factura, ahora ya lo hace.

Tambien considere agregar una pequeña verificacion si el entorno es desarrollo, para que aun asi se cancele la factura sin que pase a traves del PAC, ya que este no cancela la factura en modo desarrollo.

#548 