### PR TITLE
Error#549 Fix de Error 500 en el usuario Aux. Venta

### DIFF
--- a/app/Resources/views/tienda/venta/new.html.twig
+++ b/app/Resources/views/tienda/venta/new.html.twig
@@ -38,8 +38,8 @@
             width: 100%;
         }
 
-        .discount-input[disabled],
-        .discount-input[disabled] + span {
+        .discount-input[readonly],
+        .discount-input[readonly] + span {
             background-color: #373c52 !important;
         }
     </style>

--- a/src/AppBundle/Form/Tienda/Venta/ConceptoType.php
+++ b/src/AppBundle/Form/Tienda/Venta/ConceptoType.php
@@ -48,7 +48,7 @@ class ConceptoType extends AbstractType
         $discountAttributes = ['class' => 'discount-input'];
 
         if (!$this->security->isGranted('ROLE_ADMIN_POV')) {
-            $discountAttributes['disabled'] = 'disabled';
+            $discountAttributes['readonly'] = 'readonly';
         }
 
         $builder->addEventSubscriber(new ProductoFieldListener($this->entityManager));


### PR DESCRIPTION
La columna de descuento solo es accesible para quienes pueden dar descuento por ejemplo un administrador, la solucion que se habia dado es que para usuarios no administradores se les agregaba el atributo disabled a los usuarios normales, pero agregar ese atributo nulifica su valor, por lo que se cambio a readonly, esto evitar que puedan modificar el valor, pero su valor inicial 0, se mantiene.

#549 