### PR TITLE
Error#568 Recheck de validaciones al validar combustible x cliente y x novo

### DIFF
--- a/src/AppBundle/Controller/CombustibleController.php
+++ b/src/AppBundle/Controller/CombustibleController.php
@@ -22,10 +22,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Serializer\Encoder\JsonEncoder;
-use Symfony\Component\Serializer\Encoder\XmlEncoder;
-use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
-use Symfony\Component\Serializer\Serializer;
 
 /**
  * Gasolina cotizacion controller.

--- a/src/AppBundle/Entity/CombustibleListener.php
+++ b/src/AppBundle/Entity/CombustibleListener.php
@@ -21,6 +21,10 @@ class CombustibleListener
             return;
         }
 
+        if ($combustible->getValidacliente() !== 0) {
+            return;
+        }
+
         $producto = $combustible->getTipo();
         $cantidadInicial = $producto->getExistencia();
         $cantidadRemover = $combustible->getCantidad();

--- a/src/AppBundle/Form/CombustibleValidarType.php
+++ b/src/AppBundle/Form/CombustibleValidarType.php
@@ -33,37 +33,37 @@ class CombustibleValidarType extends AbstractType
                 'expanded' => true,
                 'multiple' => false,
                 'choice_attr' => function ($val, $key, $index) {
-                    return ['class' => 'opcion' . strtolower($key)];
+                    return ['class' => 'opcion'.strtolower($key)];
                 },
             ])
             ->add('notasnovo', TextareaType::class, [
                 'label' => 'Observaciones',
                 'attr' => ['rows' => 7],
-                'required' => false
+                'required' => false,
             ])
             ->add('validacliente', ChoiceType::class, [
                 'choices' => ['Aceptar' => 2, 'Rechazar' => 1],
                 'expanded' => true,
                 'multiple' => false,
                 'choice_attr' => function ($val, $key, $index) {
-                    return ['class' => 'opcion' . strtolower($key)];
+                    return ['class' => 'opcion'.strtolower($key)];
                 },
             ])
             ->add('notascliente', TextareaType::class, [
                 'label' => 'Observaciones',
                 'attr' => ['rows' => 7],
-                'required' => false
+                'required' => false,
             ]);
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
             $cotizacion = $event->getData();
             $form = $event->getForm();
 
-            if($cotizacion->getValidanovo() === 2){ //aceptar como cliente
+            if ($cotizacion->getValidanovo() === 2) { //aceptar como cliente
                 $form
                     ->remove('validanovo')
                     ->remove('notasnovo');
-            }else{ //validar como alguien de Novo
+            } else { //validar como alguien de Novo
                 $form
                     ->remove('validacliente')
                     ->remove('notascliente');
@@ -79,8 +79,8 @@ class CombustibleValidarType extends AbstractType
         $resolver->setDefaults([
             'data_class' => Combustible::class,
             'constraints' => [
-                new Callback([$this, 'combustibleHaveStock'])
-            ]
+                new Callback([$this, 'combustibleHaveStock']),
+            ],
         ]);
     }
 
@@ -96,9 +96,13 @@ class CombustibleValidarType extends AbstractType
     {
         $existencia = $cotizacion->getTipo()->getExistencia();
 
-        if ($cotizacion->getValidanovo() === 2 && $existencia <= 0) {
+        if (
+            $cotizacion->getValidanovo() === 2 &&
+            $cotizacion->getValidacliente() === 0 &&
+            $existencia < $cotizacion->getCantidad()
+        ) {
             $context
-                ->buildViolation('No hay suficiente inventario, Existencia actual: '.$existencia)
+                ->buildViolation('No hay suficiente inventario; Existencia actual: '.$existencia.'; Cantidad solicitada: '.$cotizacion->getCantidad())
                 ->atPath('validanovo')
                 ->addViolation();
         }


### PR DESCRIPTION
Al final verifique cual era mi error, y en efecto es este:

Al hacer la validacion por novonautica verificaba que esta fuera aceptada, si era aceptada entonces procedia con la validacion de inventario, al ser validada por el cliente, volvia a validarse el inventario (cosa que no debia hacer).

La solucion fue ignorar completamente la validacion por usuario, ya que solo se requiere validar el inventario cuando la cotizacion fue aceptada por novonautica.

En resumen:
Nueva cotizacion
Validacion por novonautica (aceptada)
Validacion por inventario
Validacion por cliente (aceptada/rechazada)
Validacion por inventario


Ahora es asi:

Nueva cotizacion
Validacion por novonautica (aceptada)
Validacion por inventario
Validacion por usuario

#568 
