### PR TITLE
Implementación#538 Ordenamiento por fecha y vista de fecha de creación

### DIFF
--- a/app/Resources/views/marinahumeda/cotizacion/estadia/index.html.twig
+++ b/app/Resources/views/marinahumeda/cotizacion/estadia/index.html.twig
@@ -102,6 +102,10 @@
               if (cotizacion[i] === 1) row.cells[i].innerHTML = rechazado;
               if (cotizacion[i] === 2) row.cells[i].innerHTML = aceptado;
             }
+            row.cells[0].innerHTML = `
+                <p>${cotizacion[0].folio}</p>
+                <p>${cotizacion[0].fecharegistro}</p>
+            `;
 
             row.cells[1].innerHTML = `
                 <dl class="dl-horizontal">

--- a/src/AppBundle/Controller/MarinaHumedaCotizacionController.php
+++ b/src/AppBundle/Controller/MarinaHumedaCotizacionController.php
@@ -176,7 +176,6 @@ class MarinaHumedaCotizacionController extends Controller
 
             //-------------------------------------------------
 
-            $fechaHoraActual = new \DateTime('now');
             $foliobase = $sistema[0]['folioMarina'];
             $folionuevo = $foliobase + 1;
 
@@ -189,7 +188,6 @@ class MarinaHumedaCotizacionController extends Controller
                 ->setValidanovo(0)
                 ->setValidacliente(0)
                 ->setEstatus(1)
-                ->setFecharegistro($fechaHoraActual)
                 ->setFolio($folionuevo)
                 ->setFoliorecotiza(0);
             $this->getDoctrine()
@@ -753,7 +751,6 @@ class MarinaHumedaCotizacionController extends Controller
             $granTotal += $total;
 
             //-------------------------------------------------
-            $fechaHoraActual = new \DateTime('now');
             $foliobase = $qb->getFolioMarina();
             $folionuevo = $foliobase + 1;
 
@@ -769,7 +766,6 @@ class MarinaHumedaCotizacionController extends Controller
                 ->setValidanovo(0)
                 ->setValidacliente(0)
                 ->setEstatus(1)
-                ->setFecharegistro($fechaHoraActual)
                 ->setFolio($folionuevo)
                 ->setFoliorecotiza(0);
             $folioactualiza = $this->getDoctrine()
@@ -934,7 +930,6 @@ class MarinaHumedaCotizacionController extends Controller
             $granTotal += $total;
 
             //-------------------------------------------------
-            $fechaHoraActual = new \DateTime('now');
             $marinaHumedaCotizacion
                 ->setCliente($cliente)
                 ->setBarco($barco)
@@ -946,8 +941,7 @@ class MarinaHumedaCotizacionController extends Controller
                 ->setTotal($granTotal)
                 ->setValidanovo(0)
                 ->setValidacliente(0)
-                ->setEstatus(1)
-                ->setFecharegistro($fechaHoraActual);
+                ->setEstatus(1);
             $marinaHumedaCotizacionAnterior
                 ->setEstatus(0);
             $em->persist($marinaHumedaCotizacion);

--- a/src/AppBundle/DataTables/MHCEstadiaDataTable.php
+++ b/src/AppBundle/DataTables/MHCEstadiaDataTable.php
@@ -89,7 +89,7 @@ class MHCEstadiaDataTable extends AbstractDataTableHandler
 
         foreach ($request->order as $order) {
             if ($order->column === 0) {
-                $q->addOrderBy('mhce.folio', $order->dir);
+                $q->addOrderBy('mhce.fecharegistro', $order->dir);
             } elseif ($order->column === 1) {
                 $q->addOrderBy('cliente.nombre', $order->dir);
             } elseif ($order->column === 2) {
@@ -129,7 +129,10 @@ class MHCEstadiaDataTable extends AbstractDataTableHandler
 
 
             $results->data[] = [
-                !$cotizacion->getFoliorecotiza() ? $cotizacion->getFolio() : $cotizacion->getFolio().'-'.$cotizacion->getFoliorecotiza(),
+                [
+                'folio' => !$cotizacion->getFoliorecotiza() ? $cotizacion->getFolio() : $cotizacion->getFolio() . '-' . $cotizacion->getFoliorecotiza(),
+                'fecharegistro' => $cotizacion->getFecharegistro()->format('d/m/Y'),
+                ],
                 [
                     'cliente' => $cotizacion->getCliente()->getNombre(),
                     'embarcacion' => $cotizacion->getBarco()->getNombre(),

--- a/src/AppBundle/Entity/MarinaHumedaCotizacion.php
+++ b/src/AppBundle/Entity/MarinaHumedaCotizacion.php
@@ -199,7 +199,7 @@ class MarinaHumedaCotizacion
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="fecharegistro", type="datetime", nullable=true)
+     * @ORM\Column(name="fecharegistro", type="datetime")
      */
     private $fecharegistro;
 
@@ -361,6 +361,7 @@ class MarinaHumedaCotizacion
         $this->registroValidaNovo = null;
         $this->registroValidaCliente = null;
         $this->registroPagoCompletado = null;
+        $this->fecharegistro = new \DateTime();
     }
 
     public function __toString()


### PR DESCRIPTION
Ahora se ordenan las cotizaciones de marina estadía en base a la fecha y se muestra la fecha en la columna de los folios.