### PR TITLE
Implementación #544 Facturacion de Astillero mejorada

### DIFF
--- a/app/Resources/views/contabilidad/facturacion/new.html.twig
+++ b/app/Resources/views/contabilidad/facturacion/new.html.twig
@@ -724,7 +724,19 @@
 
             computeConceptos();
           }).always(() => {
-            loadingState.style.display = 'none'
+            loadingState.style.display = 'none';
+            const selectedOption = cotizacionSelect.options[cotizacionSelect.selectedIndex];
+
+            if (!selectedOption.dataset.requerirFactura) return;
+
+            const clienteNombre = selectedOption.dataset.clienteNombre.substring(0, 20);
+            const clienteId = selectedOption.dataset.clienteId;
+
+            throwAlert(
+                `El cliente <a href="../../cliente/${clienteId}" target="_blank">${clienteNombre}...</a>
+                 de la cotización seleccionada solicito factura pero no ha registrado datos de facturación en el sistema.`,
+                'warning'
+            )
           });
         });
 
@@ -740,7 +752,11 @@
         // Funciones
 
         function getFolio() {
-          if (clienteSelect.value && !cotizacionSelect.value) {
+          cotizacionSelect.innerHTML = '';
+          document.getElementById('errors').innerHTML = '';
+          conceptoTable.clear();
+
+          if (clienteSelect.value) {
             getCotizaciones(emisorSelect.value, clienteSelect.value);
           }
 
@@ -759,6 +775,7 @@
         function getCotizaciones(emisor, cliente) {
           loadingState.style.display = 'block';
           cotizacionSelect.innerHTML = '';
+          document.getElementById('errors').innerHTML = '';
 
           $.get('cotizaciones',
               {
@@ -775,7 +792,15 @@
             cotizacionSelect.appendChild(new Option('Seleccione una cotización', ''));
 
             for (const result of results) {
-              cotizacionSelect.appendChild(new Option(result.text, result.id));
+              const option = new Option(result.text, result.id);
+
+              if (result.requerirFactura) {
+                option.dataset.requerirFactura = result.requerirFactura || false;
+                option.dataset.clienteNombre = result.cliente_nombre;
+                option.dataset.clienteId = result.cliente_id;
+              }
+
+              cotizacionSelect.appendChild(option);
             }
           }).always(() => {
             loadingState.style.display = 'none';
@@ -783,6 +808,8 @@
         }
 
         function computeConceptos() {
+          document.getElementById('errors').innerHTML = '';
+
           let totalValue = 0;
           let subtotalValue = 0;
           let impuestosValue = 0;

--- a/src/AppBundle/Form/Contabilidad/FacturacionType.php
+++ b/src/AppBundle/Form/Contabilidad/FacturacionType.php
@@ -230,6 +230,7 @@ class FacturacionType extends AbstractType
                 'html5' => false,
                 'widget' => 'single_text',
                 'format' => 'MMMM yyyy',
+                'attr' => ['autocomplete' => 'off']
             ]
         );
 

--- a/src/AppBundle/Repository/AstilleroCotizacionRepository.php
+++ b/src/AppBundle/Repository/AstilleroCotizacionRepository.php
@@ -441,35 +441,18 @@ class AstilleroCotizacionRepository extends \Doctrine\ORM\EntityRepository
         return $resultado;
     }
 
+    /**
+     * Cuando se busca por el cliente "Publico en general ID: 413" la busqueda se expande a todas las cotizaciones
+     * donde estas se solicito que no requerian factura o donde el cliente no tiene datos de facturacion.
+     *
+     * @param $client
+     * @param $inicio
+     * @param $fin
+     *
+     * @return array
+     */
     public function getCotizacionesFromCliente($client, $inicio, $fin)
     {
-        /*$manager = $this->getEntityManager();
-
-        $cotizaciones = $manager->createQuery(
-            'SELECT cotizaciones.id, '.
-            '(CASE '.
-            'WHEN cotizaciones.foliorecotiza > 0 '.
-            'THEN CONCAT(cotizaciones.folio, \'-\', cotizaciones.foliorecotiza, \' \', barco.nombre) '.
-            'ELSE CONCAT(cotizaciones.folio, \' \', barco.nombre) '.
-            'END) AS text '.
-            'FROM AppBundle:AstilleroCotizacion cotizaciones '.
-            'LEFT JOIN cotizaciones.barco barco '.
-            'WHERE IDENTITY(cotizaciones.cliente) = :client '.
-            'AND cotizaciones.factura IS NULL '.
-            'AND cotizaciones.validacliente = 2'.
-            'AND cotizaciones.fecharegistro BETWEEN :inicio AND :fin')
-            ->setParameter('inicio', $inicio)
-            ->setParameter('fin', $fin)
-            ->setParameter('client', $client);
-
-        // FIXME Se espera que el cliente tenga el id 413, hasta ahora este valor tiene que quedarse fijo
-        if ($client === '413') {
-            $cotizaciones[] = [
-                'id' => 'ALL',
-                'text' => 'Todas las ventas'
-            ];
-        }*/
-
         $queryBuilder = $this->createQueryBuilder('cotizaciones');
 
         $cotizacionQuery = $queryBuilder
@@ -479,7 +462,10 @@ class AstilleroCotizacionRepository extends \Doctrine\ORM\EntityRepository
                 'WHEN cotizaciones.foliorecotiza > 0 '.
                 'THEN CONCAT(cotizaciones.folio, \'-\', cotizaciones.foliorecotiza, \' \', barco.nombre) '.
                 'ELSE CONCAT(cotizaciones.folio, \' \', barco.nombre) '.
-                'END) AS text'
+                'END) AS text',
+                'cotizaciones.requerirFactura',
+                'cliente.id AS cliente_id',
+                'cliente.nombre AS cliente_nombre'
             )
             ->leftJoin('cotizaciones.barco', 'barco')
             ->leftJoin('cotizaciones.cliente', 'cliente')


### PR DESCRIPTION
Ahora las cotizaciones donde se selecciona el cliente "PUBLICO EN GENERAL" y
emisor astillero, muestra las cotizaciones disponibles en las que no se
solicito una factura o donde el cliente no tiene datos de facturacion y
ademas muestran una alerta donde se indica que el cliente solicito
factura pero no tiene datos de facturacion

#544 