### PR TITLE
Implementación#550 Vista del select de proveedores por razón social

### DIFF
--- a/src/AppBundle/Form/Astillero/ProductoType.php
+++ b/src/AppBundle/Form/Astillero/ProductoType.php
@@ -66,7 +66,8 @@ class ProductoType extends AbstractType
                         return $er->createQueryBuilder('proveedor')
                             ->where('proveedor.proveedorcontratista = 0')
                             ->andWhere('proveedor.empresa = 5');
-                    }
+                    },
+                    'choice_label' => 'razonsocial',
                 ],
                 'allow_add' => true,
                 'allow_delete' => true,


### PR DESCRIPTION
Ahora en el select de los proveedores de Astillero/Productos se muestra la razón social en vez del nombre.