### PR TITLE
Reparación marina cotización días y tarifas

### DIFF
--- a/app/Resources/views/marinahumeda/cotizacion/estadia/new.html.twig
+++ b/app/Resources/views/marinahumeda/cotizacion/estadia/new.html.twig
@@ -166,6 +166,7 @@
                                     </div>
                                     <label>Días Estadía:</label>
                                     {{ form_widget(form.diasEstadia) }}
+                                    {{ form_errors(form.diasEstadia) }}
                                     <div class="security-icon">
                                         <i class="fa fa-lock" aria-hidden="true"></i>
                                     </div>
@@ -693,33 +694,49 @@
         }
 
         function filtraSelectPrecios(listado, eslora) {
+          let countOptions = 0;
+          let itemSeleccionable = null;
+
           listado.childNodes.forEach((item) => {
             let piesA = Number(item.dataset.pies_a);
             let piesB = Number(item.dataset.pies_b);
             let clasificacion = Number(item.dataset.clasificacion);
 
             if(estatusPincodeHide.value === '1'){
+
               (eslora >= piesA && eslora <= piesB) ?
-                item.classList.remove('hide') :
+                (item.classList.remove('hide'),
+                  countOptions++) :
                 item.classList.add('hide');
+
             }else{
-              !(eslora >= piesA && eslora <= piesB && clasificacion === 0) ?
-                item.classList.add('hide') :
+
+              if(!(eslora >= piesA && eslora <= piesB && clasificacion === 0)) {
+                item.classList.add('hide');
+              } else {
                 item.classList.remove('hide');
+                itemSeleccionable = item;
+                countOptions++;
+              }
             }
+
           });
+          procesaSelectAutomatico(countOptions, listado, itemSeleccionable);
         }
 
         function desbloqueaSelectPrecios(listado, eslora){
           if(estatusPincodeHide.value === '1' && listado) {
+            let countOptions = 0;
+
             listado.childNodes.forEach((item) => {
                 let piesA = Number(item.dataset.pies_a);
                 let piesB = Number(item.dataset.pies_b);
 
                 !(eslora >= piesA && eslora <= piesB) ?
                 item.classList.add('hide') :
-                item.classList.remove('hide');
+                  (item.classList.remove('hide'), countOptions++);
             });
+            procesaSelectAutomatico(countOptions, listado, null);
           }
         }
 
@@ -733,6 +750,19 @@
             securityIcons.forEach((icon) => {
               icon.innerHTML = '<i class="fa fa-unlock letra-verde" aria-hidden="true"></i>';
             });
+          }
+        }
+
+        function procesaSelectAutomatico(countOptions, select, item){
+          if(countOptions === 0) {
+              let opt = document.createElement('option');
+              opt.appendChild(document.createTextNode('Sin tarifa general aplicable'));
+              opt.setAttribute('selected', 'selected');
+              select.appendChild(opt);
+          } else if (countOptions === 1) {
+            if (item) {
+              item.setAttribute('selected', 'selected');
+            }
           }
         }
 

--- a/src/AppBundle/Form/MarinaHumedaCotizacionType.php
+++ b/src/AppBundle/Form/MarinaHumedaCotizacionType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\FormInterface;
 use AppBundle\Entity\Cliente;
-
+use Symfony\Component\Validator\Constraints as Assert;
 
 class MarinaHumedaCotizacionType extends AbstractType
 {
@@ -56,6 +56,11 @@ class MarinaHumedaCotizacionType extends AbstractType
             ->add('diasEstadia',TextType::class,[
                 'label'=>'Días Estadia',
                 'attr' => ['class' => 'esnumero','readonly' => true],
+                'constraints' => [
+                    new Assert\NotBlank([
+                        'message' => 'Debe seleccionar rango de fechas'
+                    ])
+                ]
             ])
             ->add('descuentoEstadia', NumberType::class, [
                 'label' => 'Descuento estadía %',

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -763,7 +763,7 @@ function diasEntreFechas(inicio, fin) {
   var end = new Date(fin.toString());
   var diff = new Date(end - start);
   var days = (diff / 1000 / 60 / 60 / 24);
-  return days+1;
+  return days;
 }
 function totalDiasLaborales(start, end) {
     // This makes no effort to account for holidays


### PR DESCRIPTION
Ahora al seleccionar las fechas se contabiliza un día menos.
Ahora al seleccionar un barco los select de tarifas se seleccionan automaticamente,
en caso de no tener tarifas aparecerá el texto "sin tarifa general aplicable".
Reparado agregado verificación campo de dias estadia no puede quedar en blanco.